### PR TITLE
Changes to remove deprecated list function so that terraform >v0.12 can deploy SadCloud

### DIFF
--- a/modules/aws/cloudtrail/main.tf
+++ b/modules/aws/cloudtrail/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudtrail" "main" {
   enable_log_file_validation = !var.no_log_file_validation
 
   dynamic "event_selector" {
-    for_each = var.no_data_logging == true ? [] : list(var.no_data_logging)
+    for_each = var.no_data_logging == true ? [] : tolist([var.no_data_logging])
 
     content {
       read_write_type           = "All"

--- a/modules/aws/s3/main.tf
+++ b/modules/aws/s3/main.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "main" {
   force_destroy = true
 
   dynamic "server_side_encryption_configuration" {
-    for_each = var.no_default_encryption ? [] : list(var.no_default_encryption)
+    for_each = var.no_default_encryption ? [] : tolist([var.no_default_encryption])
 
     content {
       rule {
@@ -16,7 +16,7 @@ resource "aws_s3_bucket" "main" {
   }
 
   dynamic "logging" {
-    for_each = var.no_logging ? [] : list(var.no_logging)
+    for_each = var.no_logging ? [] : tolist([var.no_logging])
 
     content {
       target_bucket = aws_s3_bucket.logging[0].id
@@ -30,7 +30,7 @@ resource "aws_s3_bucket" "main" {
   }
 
   dynamic "website" {
-    for_each = var.website_enabled ? [] : list(var.website_enabled)
+    for_each = var.website_enabled ? [] : tolist([var.website_enabled])
 
     content {
       index_document = "index.html"


### PR DESCRIPTION
Currently the terraform files for some AWS services have a function call which has been deprecated since v0.12.
I have changed the function calls so that newer versions of terraform can be used to deploy SadCloud.

Changes to /modules/aws/s3/main.tf and /modules/aws/cloudtrail/main.tf